### PR TITLE
Added navigation logic to main.js and added home.html, cinematics.html and triptyk.html

### DIFF
--- a/final/css/styles.css
+++ b/final/css/styles.css
@@ -1,20 +1,23 @@
-body{
+body {
   background-color: #e8e4e4;
 }
-.menu-list{
+
+.menu-list {
   margin: 0 auto;
   width: 60%;
   margin: 0 auto;
   text-align: center;
   height: 60px;
 }
-#author{
+
+#author {
   font-size: 24px;
-  padding:15px;
+  padding: 15px;
   text-decoration: none;
   color: #2d5052;
 }
-nav{
+
+nav {
   width: 100%;
   height: 60px;
   position: absolute;
@@ -22,16 +25,24 @@ nav{
   top: 0;
   border-bottom: 1px #2d5052 solid;
 }
-nav ul{
+
+nav ul {
   list-style: none;
 }
-nav ul li{
+
+nav ul li {
   float: left;
 }
-.menu-item{
+
+.menu-item {
   padding: 20px;
-}
-a.menu-item{
   text-decoration: none;
   color: #2d5052;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 200px;
 }

--- a/final/js/main.js
+++ b/final/js/main.js
@@ -1,0 +1,46 @@
+/**
+ * This is the main script for the site.
+ */
+
+var ul = document.getElementById('nav-list');
+
+/**
+ * When the html page is loaded the loadMain function is run.
+ */
+window.onload = loadMain;
+
+/**
+ * getEventTarget - Gets the target for the event.
+ *
+  * http://stackoverflow.com/questions/5116929/get-clicked-li-from-ul-onclick
+ * @param  {event} e event
+ * @return {DOM element}   event target
+ */
+function getEventTarget(e) {
+    e = e || window.event;
+    return e.target || e.srcElement;
+}
+
+/**
+ * loadMain - Loads the home page.
+ */
+function loadMain() {
+    var inner = '<object type="text/html" data=home.html></object>';
+    document.getElementById("content").innerHTML = inner;
+}
+
+/**
+ * ul.onClick - onClick-handler for ul.
+ *
+ * @param  {event} event the click event.
+ */
+ul.onclick = function(event) {
+    var li = getEventTarget(event);
+    if (li === null) {
+        console.log("List item was not found in the navigation bar.");
+    } else {
+        var url = li.dataset.url;
+        var inner = '<object type="text/html" data=' + url + '.html></object>';
+        document.getElementById("content").innerHTML = inner;
+    }
+};

--- a/final/pages/cinematics.html
+++ b/final/pages/cinematics.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Cinematics</title>
+  </head>
+  <body>
+    <p>
+      This is the cinematics page.
+    </p>
+  </body>
+</html>

--- a/final/pages/home.html
+++ b/final/pages/home.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Home</title>
+  </head>
+  <body>
+    <p>
+      This is the home page.
+    </p>
+  </body>
+</html>

--- a/final/pages/main.html
+++ b/final/pages/main.html
@@ -1,30 +1,32 @@
+<!DOCTYPE html>
+<html lang="en-US" />
+
 <head>
+  <script src="../js/main.js" async></script>
+  <link rel="stylesheet" type="text/css" href="../css/styles.css" />
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" type="text/css" href="../css/styles.css" />
   <meta name=keywords content="fotografi, kunst, kunstfoto" />
-  <title>Final Website</title>
+  <title>Main page (navigation)</title>
 </head>
+
 <body>
   <div class="wrapper">
     <nav>
-      <div class="menu-list">
-      <ul>
-        <li><a href=# class=menu-item>Cinematics</a></li>
-        <li><a href=# class=menu-item>Triptyk</a></li>
-        <li><a href=# class=menu-item>Flykt</a></li>
-        <li><a href=# class=menu-item>Glød</a></li>
-        <li><a href=# id=author>Daniel Bolstad</a></li>
-        <li><a href=# class=menu-item>Pandora</a></li>
-        <li><a href=# class=menu-item>Icarus</a></li>
-        <li><a href=# class=menu-item>Matthew</a></li>
-        <li><a href=# class=menu-item>Kings</a></li>
+      <ul class="menu-list" id="nav-list" onclick="loadPage()">
+        <li data-url="cinematics" class="menu-item">Cinematics</li>
+        <li data-url="triptyk" class="menu-item">Triptyk</li>
+        <li data-url="flykt" class="menu-item">Flykt</li>
+        <li data-url="glod" class="menu-item">Glød</li>
+        <li data-url="home" class="menu-item" id="author">Daniel Bolstad</li>
+        <li data-url="pandora" class="menu-item">Pandora</li>
+        <li data-url="icarus" class="menu-item">Icarus</li>
+        <li data-url="matthew" class="menu-item">Matthew</li>
+        <li data-url="kings" class="menu-item">Kings</li>
       </ul>
-      <div>
     </nav>
-    <section>
-    </section>
+    <div class="content" id="content"></div>
   </div>
-
 </body>
+
 </html>

--- a/final/pages/triptyk.html
+++ b/final/pages/triptyk.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Triptyk</title>
+  </head>
+  <body>
+    <p>
+      This is the triptyk page.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
Hei, har lagt til logikk for navigasjonsmenyen nå. Ta ein kikk ved å sjekke ut branchen "navbar" før vi evt. legger den til i "develop"-branchen.

I denne branchen er det lagt til logikk for å navigere mellom sidene i navigasjonsmenyen. Foreløbig er det kun logikken for de enkelte gallerisidene og hovedsiden som er lagt til, men resten får vi på plass etterkvart.

Sondre: Håper at eg ikkje har rota til stylinga som du la til, ser bra ut!

Logikken er som følger (spør viss dere lurer på noe):
I main.html ligger navigasjonsmenyen med linker til alle html-sidene. Html-sidene lastes inn (ved bruk av AJAX) og puttes i div-en "content". På denne måten trenger vi kun å lage navigasjonen i main.html og putter heller alt det andre inn i main.html som undersider. Når man klikker eit eller anna sted inne i lista med navigasjonselementer trigges "onClick"-eventet for lista og getEventTarget-funksjonen finner ut kva for listelement som blei klikka på. Og så skjer magien med at "content" får nytt html-innhold ved å sette innerHTML-attributten. "data-url" er ein egendefinert atributt som eg bruker for å angi html-siden som skal brukes for kvart listeelement.
